### PR TITLE
Add dashboard view with results data

### DIFF
--- a/public/data/results.json
+++ b/public/data/results.json
@@ -1,0 +1,7 @@
+{
+  "participants": [
+    { "id": 1, "name": "Rahim", "score": 65, "personality": "INTJ" },
+    { "id": 2, "name": "Karim", "score": 78, "personality": "ENFP" },
+    { "id": 3, "name": "Tamanna", "score": 82, "personality": "ISTJ" }
+  ]
+}

--- a/src/Dashboard.css
+++ b/src/Dashboard.css
@@ -1,0 +1,33 @@
+.dashboard {
+  padding: 1rem;
+  font-family: sans-serif;
+}
+.summary {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+.metric {
+  flex: 1 1 150px;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  text-align: center;
+  background: #f9f9f9;
+}
+.participants-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+.participant-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.participant-card h3 {
+  margin-top: 0;
+}

--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import './Dashboard.css'
+
+function Dashboard() {
+  const [participants, setParticipants] = useState([])
+
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const res = await fetch('/data/results.json')
+        const json = await res.json()
+        setParticipants(json.participants || [])
+      } catch (err) {
+        console.error('Failed to load data', err)
+      }
+    }
+    loadData()
+  }, [])
+
+  const total = participants.length
+  const average = total > 0
+    ? Math.round(participants.reduce((sum, p) => sum + p.score, 0) / total)
+    : 0
+
+  return (
+    <div className="dashboard">
+      <h1>Personality Test Dashboard</h1>
+      <div className="summary">
+        <div className="metric">
+          <h2>Total Participants</h2>
+          <p>{total}</p>
+        </div>
+        <div className="metric">
+          <h2>Average Score</h2>
+          <p>{average}</p>
+        </div>
+      </div>
+      <div className="participants-grid">
+        {participants.map((p) => (
+          <div key={p.id} className="participant-card">
+            <h3>{p.name}</h3>
+            <p>Score: {p.score}</p>
+            <p>Personality: {p.personality}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default Dashboard

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.jsx'
+import Dashboard from './Dashboard.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <Dashboard />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add Dashboard component that fetches personality test results and displays summary metrics and participant cards
- style dashboard with responsive grid layout
- make Dashboard the root view and include sample results data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ec6d5bcc832986cf4fad2c6e505d