### PR TITLE
Add responsive dashboard styles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import './dashboard.css'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -28,6 +29,24 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
+      <div
+        className="dashboard-grid"
+        role="region"
+        aria-label="Dashboard overview"
+      >
+        <div className="dashboard-card" role="article" aria-label="Sample card">
+          <h2>Example Card</h2>
+          <p>Card content goes here.</p>
+        </div>
+        <div
+          className="dashboard-chart"
+          role="img"
+          aria-label="Placeholder chart"
+          tabIndex="0"
+        >
+          Chart
+        </div>
+      </div>
     </>
   )
 }

--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -1,0 +1,62 @@
+/* Dashboard layout styles */
+
+.dashboard-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  padding: 1rem;
+}
+
+.dashboard-card {
+  background-color: #ffffff;
+  color: #1a1a1a;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.dashboard-card h2 {
+  font-size: 1.25rem;
+  margin-top: 0;
+}
+
+.dashboard-card:focus-within {
+  outline: 3px solid #646cff;
+  outline-offset: 2px;
+}
+
+.dashboard-chart {
+  background-color: #ffffff;
+  color: #1a1a1a;
+  border: 2px solid #1a1a1a;
+  border-radius: 8px;
+  padding: 1rem;
+  height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+}
+
+.dashboard-chart:focus {
+  outline: 3px solid #646cff;
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .dashboard-card,
+  .dashboard-chart {
+    font-size: 0.875rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .dashboard-card,
+  .dashboard-chart {
+    background-color: #1e1e1e;
+    color: #f9f9f9;
+    border-color: #f9f9f9;
+  }
+}


### PR DESCRIPTION
## Summary
- add dashboard.css with responsive grid, card, and chart styles
- import new styles and example ARIA-labelled dashboard elements

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7ec7a5bb483299d0613d377580b98